### PR TITLE
Update stylelint and remove depricated rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = {
     'scss/selector-no-redundant-nesting-selector': true,
     'selector-list-comma-newline-after': 'always',
     'selector-max-compound-selectors': 4,
-    'selector-no-id': true,
+    'selector-max-id': 0,
     'selector-no-qualifying-type': true,
     'selector-no-vendor-prefix': true,
     'selector-pseudo-element-colon-notation': 'double',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-tictail",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Stylelint config used by Tictail",
   "keywords": [
     "stylelint",
@@ -23,8 +23,8 @@
     "eslint-config-tictail": "~1.0.0",
     "jest": "~20.0.4",
     "prettier": "~1.3.1",
-    "stylelint": "~7.10.1",
-    "stylelint-scss": "~1.4.4"
+    "stylelint": "~8.0.0",
+    "stylelint-scss": "~2.0.0"
   },
   "scripts": {
     "lint": "eslint ./ --max-warnings 0 --ext .js",


### PR DESCRIPTION
I started getting warnings for a now deleted rule (`selector-no-id`) in my Atom editor after updating the `linter-stylelint` package which I guess uses the newer version of `stylelint`.

So this PR replaces `selector-no-id rule: true` with `selector-max-id: 0`. This is what they recommend [here](https://github.com/stylelint/stylelint/blob/master/CHANGELOG.md#7120).